### PR TITLE
Removed azure-cli commands

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,3 @@
-brew update && brew install azure-cli
-
 echo "Logging in to Azure..."
 az login --service-principal -u $AZUREAPPID -p $AZUREAPPKEY --tenant $AZUREAPPTENANT
 


### PR DESCRIPTION
Removed "brew update && brew install azure-cli"

This is no longer required as the Hosted MAC Build Agent mow includes the azure-cli.